### PR TITLE
Go back changes from minreq until timewait connections fix

### DIFF
--- a/src/bitcoin_client.rs
+++ b/src/bitcoin_client.rs
@@ -1,5 +1,5 @@
 use crate::errors::BitcoinClientError;
-use crate::minreq_https::MinreqHttpsTransport;
+//use crate::minreq_https::MinreqHttpsTransport;
 use crate::rpc_config::RpcConfig;
 use crate::types::{BlockHeight, BlockInfo};
 use bitcoin::consensus::encode::serialize_hex;
@@ -8,7 +8,7 @@ use bitcoin::{
 };
 use bitcoincore_rpc::json::GetBlockchainInfoResult;
 use bitcoincore_rpc::json::GetTxOutResult;
-use bitcoincore_rpc::{jsonrpc, Client, RpcApi};
+use bitcoincore_rpc::{Client, RpcApi, Auth};
 use mockall::automock;
 
 #[derive(Debug)]
@@ -18,22 +18,25 @@ pub struct BitcoinClient {
 
 impl BitcoinClient {
     pub fn new(url: &str, user: &str, pass: &str) -> Result<Self, BitcoinClientError> {
-        let pass = match pass.is_empty() {
-            true => None,
-            false => Some(pass.to_owned()),
-        };
+        // let pass = match pass.is_empty() {
+        //     true => None,
+        //     false => Some(pass.to_owned()),
+        // };
 
-        let transport = if user != "" {
-            MinreqHttpsTransport::builder()
-                .url(url)?
-                .basic_auth(user.to_owned(), pass)
-                .build()
-        } else {
-            MinreqHttpsTransport::builder().url(url)?.build()
-        };
+        // let transport = if user != "" {
+        //     MinreqHttpsTransport::builder()
+        //         .url(url)?
+        //         .basic_auth(user.to_owned(), pass)
+        //         .build()
+        // } else {
+        //     MinreqHttpsTransport::builder().url(url)?.build()
+        // };
 
-        let from_jsonrpc = jsonrpc::client::Client::with_transport(transport);
-        let client = Client::from_jsonrpc(from_jsonrpc);
+        //let from_jsonrpc = jsonrpc::client::Client::with_transport(transport);
+        //let client = Client::from_jsonrpc(from_jsonrpc);
+
+        let auth = Auth::UserPass(user.to_owned(), pass.to_owned());
+        let client = Client::new(url, auth)?;
 
         Ok(Self { client })
     }


### PR DESCRIPTION
Martin found the following error:

> Buenas, encontre que el cambio en ruts-bitvmx-bitcoin-rpc para usar minreq esta dejando miles de conneciones en timewait (al punto de agotar los puertos en algunos esecenarios)
