### PR TITLE
Add new constructor with wallet, it does not brake prior interface

### DIFF
--- a/src/bitcoin_client.rs
+++ b/src/bitcoin_client.rs
@@ -8,7 +8,7 @@ use bitcoin::{
 };
 use bitcoincore_rpc::json::GetBlockchainInfoResult;
 use bitcoincore_rpc::json::GetTxOutResult;
-use bitcoincore_rpc::{Client, RpcApi, Auth};
+use bitcoincore_rpc::{Auth, Client, RpcApi};
 use mockall::automock;
 
 #[derive(Debug)]
@@ -45,24 +45,12 @@ impl BitcoinClient {
         Self::new(&config.url, &config.username, &config.password)
     }
 
-    pub fn new_with_wallet(url: &str, user: &str, pass: &str, wallet_name:&str) -> Result<Self, BitcoinClientError> {
-        // let pass = match pass.is_empty() {
-        //     true => None,
-        //     false => Some(pass.to_owned()),
-        // };
-
-        // let transport = if user != "" {
-        //     MinreqHttpsTransport::builder()
-        //         .url(url)?
-        //         .basic_auth(user.to_owned(), pass)
-        //         .build()
-        // } else {
-        //     MinreqHttpsTransport::builder().url(url)?.build()
-        // };
-
-        //let from_jsonrpc = jsonrpc::client::Client::with_transport(transport);
-        //let client = Client::from_jsonrpc(from_jsonrpc);
-
+    pub fn new_with_wallet(
+        url: &str,
+        user: &str,
+        pass: &str,
+        wallet_name: &str,
+    ) -> Result<Self, BitcoinClientError> {
         let url = if !wallet_name.is_empty() {
             format!("{}/wallet/{}", url.to_string(), wallet_name)
         } else {


### PR DESCRIPTION
Added a new constructor instead of an optional parameter in original so it does not brake the interface.

Allows to connect to the node is a wallet was already initialized, preventing

`Wallet file not specified (must request wallet RPC through /wallet/<filename> uri-path`
