### PR TITLE
Add mine_blocks

### DIFF
--- a/src/bitcoin_client.rs
+++ b/src/bitcoin_client.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 use crate::errors::BitcoinClientError;
 use crate::reqwest_https::ReqwestHttpsTransport;
 use crate::rpc_config::RpcConfig;
@@ -92,6 +94,11 @@ pub trait BitcoinClientApi {
         &self,
         tx_id: &Txid,
     ) -> Result<GetRawTransactionResult, BitcoinClientError>;
+
+    fn mine_blocks(
+        &self,
+        block_num: u64,
+    ) -> Result<(), BitcoinClientError>;
 
     fn mine_blocks_to_address(
         &self,
@@ -267,6 +274,18 @@ impl BitcoinClientApi for BitcoinClient {
     fn get_transaction(&self, txid: &Txid) -> Result<Option<Transaction>, BitcoinClientError> {
         let tx = self.client.get_raw_transaction(txid, None).ok();
         Ok(tx)
+    }
+
+    fn mine_blocks(
+        &self,
+        block_num: u64,
+    ) -> Result<(), BitcoinClientError> {
+        // send to an empty address to avoid changing the balance of a wallet
+        let address = Address::from_str("mkHS9ne12qx9pS9VojpwU5xtRd4T7X7ZUt")?.require_network(Network::Regtest)?;
+
+        self.mine_blocks_to_address(block_num, &address)?;
+
+        Ok(())
     }
 
     fn mine_blocks_to_address(

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -8,6 +8,9 @@ pub enum BitcoinClientError {
     #[error("Invalid block height")]
     InvalidHeight,
 
+    #[error("Error parsing address {0}")]
+    ParseAddressError(#[from] bitcoin::address::ParseError),
+
     #[error("Error creating client {0}")]
     NewClientError(#[from] reqwest_https::Error),
 


### PR DESCRIPTION
Motivation: we want to mine blocks without knowing needing and address, or to avoid sending funds to one of our known wallets.
We send the coinbase tx to `mkHS9ne12qx9pS9VojpwU5xtRd4T7X7ZUt` that is not used inside our wallets as it's a legacy address.
This function is only available on regtest