### PR TITLE
Use no-provider rustls backend for reqwest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ bitcoincore-rpc = "0.19"
 thiserror = "2.0.12"
 serde = { version = "1.0.205", features = ["derive"] }
 serde_json = { version = "1", features = ["raw_value"] }
-reqwest = { version = "0.12.10", features = ["json", "rustls-tls", "blocking"] }
+reqwest = { version = "0.12.10", features = ["json", "rustls-tls-webpki-roots-no-provider", "blocking"] }
 mockall = "0.13.0"
 tracing = "0.1.41"
 redact = { version = "0.1", features = ["serde"] }


### PR DESCRIPTION
`reqwest` stops bundling ring